### PR TITLE
Fix 'Il territorio' translation

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -63,7 +63,7 @@ function Menu({ isMenuOpen, setIsMenuOpen }) {
         </li>
         <li>
           <Link to={`/${lang}/il-territorio`} onClick={closeMenu}>
-            <Trans>Il teritorio</Trans>
+            <Trans>Il territorio</Trans>
           </Link>
         </li>
         <li>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -235,7 +235,7 @@ msgid "Il tempo trova sempre la via."
 msgstr "Time always finds a way."
 
 #: src/components/Menu.js:66
-msgid "Il teritorio"
+msgid "Il territorio"
 msgstr "Our territory"
 
 #: src/components/CookiePolicy.js:26

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -235,8 +235,8 @@ msgid "Il tempo trova sempre la via."
 msgstr "Il tempo trova sempre la via."
 
 #: src/components/Menu.js:66
-msgid "Il teritorio"
-msgstr "Il teritorio"
+msgid "Il territorio"
+msgstr "Il territorio"
 
 #: src/components/CookiePolicy.js:26
 msgid "In base alle Linee Guida del Garante della Privacy italiano, questo sito è esente dall’obbligo di banner per i cookie."

--- a/src/locales/srd/messages.po
+++ b/src/locales/srd/messages.po
@@ -235,7 +235,7 @@ msgid "Il tempo trova sempre la via."
 msgstr "Su tempus agatat semper su caminu."
 
 #: src/components/Menu.js:66
-msgid "Il teritorio"
+msgid "Il territorio"
 msgstr "Su territoriu"
 
 #: src/components/CookiePolicy.js:26


### PR DESCRIPTION
## Summary
- correct Italian spelling in the menu
- sync translation files for "Il territorio"

## Testing
- `npm run messages:compile` *(fails: lingui not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b4cf5c648320b4090b50ea20140a