### PR TITLE
Fix App test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders logo', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const logo = screen.getByAltText('deperu-holler-logo');
+  expect(logo).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update the default test to render `<App />`
- assert that the logo is in the document

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b9e51a5c8320988aabd79a40fac2